### PR TITLE
fix: locks rector/rector to 0.17.0 to fix bug in later version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "type": "library",
     "require": {
         "php": "^8.1",
-        "rector/rector": "^0.14.8 || ^0.15.0",
-        "driftingly/rector-laravel": "^0.14.1"
+        "rector/rector": "0.17.0",
+        "driftingly/rector-laravel": "0.21.0"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
@see https://github.com/driftingly/rector-laravel/issues/115