### PR TITLE
chore(deps): unlock Rector dependency versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "type": "library",
     "require": {
         "php": "^8.1",
-        "rector/rector": "0.17.0",
-        "driftingly/rector-laravel": "0.21.0"
+        "rector/rector": "^0.18.13",
+        "driftingly/rector-laravel": "^0.26.2"
     },
     "license": "MIT",
     "authors": [

--- a/dist/rector.php
+++ b/dist/rector.php
@@ -24,15 +24,11 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->skip([
-        // \Rector\TypeDeclaration\Rector\FunctionLike\ReturnTypeDeclarationRector::class, // adds return types which may conflict with Laravel built-ins
-        \Rector\TypeDeclaration\Rector\Closure\AddClosureReturnTypeRector::class, // adds return type to closures which may conflict with Laravel built-ins
-        \Rector\EarlyReturn\Rector\If_\ChangeOrIfReturnToEarlyReturnRector::class, // forces an early return which is soemtimes less easier to read
         \Rector\DeadCode\Rector\ClassMethod\RemoveUselessParamTagRector::class, // removes @param from docblocks
         \Rector\DeadCode\Rector\ClassMethod\RemoveUselessReturnTagRector::class, // removes return from docblocks
         \Rector\CodingStyle\Rector\PostInc\PostIncDecToPreIncDecRector::class, // changes $i++ to ++$i
         \Rector\CodingStyle\Rector\Encapsed\EncapsedStringsToSprintfRector::class, // changes "th{$is}" to sprintf('th%s', 'is')
         \Rector\Php80\Rector\FunctionLike\MixedTypeRector::class, // removes docblocks
-        \Rector\Php80\Rector\FunctionLike\UnionTypesRector::class, // removes docblocks
     ]);
 
 };


### PR DESCRIPTION
This PR undoes the version lock added by https://github.com/stickeeuk/rector-config/pull/13.

It also removes some rules we were skipping because they have been removed from rector, such as `https://github.com/rectorphp/rector-src/pull/3916` from https://github.com/rectorphp/rector/releases/tag/0.17.0.