### PR TITLE
chore(deps): update Rector and Rector Laravel to latest

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,8 +3,8 @@
     "type": "library",
     "require": {
         "php": "^8.3",
-        "rector/rector": "^1.2.10",
-        "driftingly/rector-laravel": "^1.2.6"
+        "rector/rector": "^2.0.7",
+        "driftingly/rector-laravel": "^2.0.2"
     },
     "license": "MIT",
     "authors": [


### PR DESCRIPTION
BREAKING CHANGE: Rector has been updated from v1 to v2 and so this package will match the major version bump.